### PR TITLE
starter-template: Add utility classes and styles

### DIFF
--- a/src/app/styles/global/_normalize.scss
+++ b/src/app/styles/global/_normalize.scss
@@ -49,12 +49,15 @@
 
 :where(h1) {
     font-size: $font-size-8;
-    max-inline-size: $size-header-1;
 }
 
-:where(h3, h4, h5, h6, dt) {
-    max-inline-size: $size-header-3;
+:where(h2) {
+    font-size: $font-size-6;
 }
+
+:where(h3) { font-size: $font-size-5; }
+:where(h4) { font-size: $font-size-4; }
+:where(h5) { font-size: $font-size-3; }
 
 :where(p, ul, ol, dl, h6) {
     font-size: $font-size-2;
@@ -113,6 +116,10 @@ summary,
 ::placeholder {
     color: $gray-7;
     opacity: 0.75;
+
+    @include color-scheme($OSdark) {
+        color: $gray-6;
+    }
 }
 
 :where(input:not([type='range']), textarea) {
@@ -125,8 +132,19 @@ summary,
     padding-block: 0.75ch;
 }
 
+:where(textarea, select, input:not([type='button'],[type='submit'],[type='reset'])) {
+    background-color: var(--surface-2);
+    border-radius: $radius-2;
+}
+
 :where(textarea) { resize: block; }
 
+:where(input[type='checkbox'], input[type='radio']) {
+    block-size: $size-3;
+    inline-size: $size-3;
+}
+
+:where(code, kbd, samp, pre) { font-family: $font-mono; }
 :where(:not(pre) > code, kbd) { white-space: nowrap; }
 
 :where(pre) {
@@ -137,10 +155,201 @@ summary,
     direction: ltr;
 }
 
+:where(:not(pre) > code) {
+    padding: $size-1 $size-2;
+    background: var(--surface-2);
+    border-radius: $radius-2;
+    writing-mode: lr;
+}
+
+:where(kbd, var) {
+    padding: $size-1 $size-2;
+    border-width: $border-size-1;
+    border-color: var(--surface-4);
+    border-radius: $radius-2;
+}
+
+:where(mark) {
+    border-radius: $radius-2;
+    padding-inline: $size-1;
+}
+
+:where(ol, ul) { padding-inline-start: $size-8; }
+:where(li) { padding-inline-start: $size-2; }
+:where(dt, summary) { font-weight: $font-weight-7; }
+
+:where(p) {
+    text-wrap: pretty;
+}
+
+:where(hr) {
+    margin-block: $size-fluid-5;
+    height: $border-size-2;
+    background-color: var(--surface-3);
+}
+
+:where(figure) {
+    display: grid;
+    gap: $size-2;
+    place-items: center;
+
+    :where(figcaption) {
+        font-size: $font-size-1;
+        text-wrap: balance;
+    }
+}
+
+:where(blockquote, :not(blockquote) cite) {
+    border-inline-start-width: $border-size-3;
+}
+
+:where(blockquote) {
+    display: grid;
+    gap: $size-3;
+    padding-block: $size-3;
+    padding-inline: $size-4;
+}
+
+:where(:not(blockquote) > cite) {
+    padding-inline-start: $size-2;
+}
+
+:where(summary) {
+    background: var(--surface-3);
+    padding: $size-2 $size-3;
+    margin: calc($size-2 * -1) calc($size-3 * -1);
+    border-radius: $radius-2;
+}
+
+:where(details) {
+    padding-inline: $size-3;
+    padding-block: $size-2;
+    background: var(--surface-2);
+    border-radius: $radius-2;
+}
+
+:where(details[open] > summary) {
+    margin-bottom: $size-2;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
+}
+
+:where(fieldset) {
+    border-radius: $radius-2;
+    border: $border-size-1 solid var(--surface-4);
+}
+
+:where(del) {
+    background: $red-9;
+    color: $red-2;
+}
+
+:where(ins) {
+    background: $green-9;
+    color: $green-1;
+}
+
+:where(abbr) {
+    text-decoration-color: $blue-5;
+}
+
+:where(dialog) {
+    background-color: var(--surface-1);
+    color: inherit;
+    border-radius: $radius-3;
+
+    &::backdrop {
+        backdrop-filter: blur(25px);
+    }
+}
+
+:where(html:has(dialog[open])) {
+    overflow: hidden;
+}
+
+:where(menu) {
+    padding-inline-start: 0;
+    display: flex;
+    gap: var(--size-3);
+}
+
+:where(sup) {
+    font-size: 0.5em;
+}
+
+:where(table) {
+    width: fit-content;
+    border: 1px solid var(--surface-2);
+    background: var(--surface-2);
+    border-radius: $radius-3;
+}
+
+:where(table:not(:has(tfoot)) tr:last-child td:first-child) {
+    border-end-start-radius: var($nice-inner-radius);
+}
+
+:where(table:not(:has(tfoot)) tr:last-child td:last-child) {
+    border-end-end-radius: var($nice-inner-radius);
+}
+
+:where(table thead tr:first-child th:first-child) {
+    border-start-start-radius: var($nice-inner-radius);
+}
+
+:where(table thead tr:first-child th:last-child) {
+    border-start-end-radius: var($nice-inner-radius);
+}
+
+:where(tfoot tr:last-child :is(th,td):first-of-type) {
+    border-end-start-radius: var($nice-inner-radius);
+}
+
+:where(tfoot tr:last-child :is(th,td):last-of-type) {
+    border-end-end-radius: var($nice-inner-radius);
+}
+
+:where(th) {
+    color: var(--text-1);
+    background-color: var(--surface-2);
+}
+
+:where(table :is(a, button, [contenteditable]):is(:focus-visible)) {
+    outline-offset: -2px;
+}
+
+:where(td) {
+    background: var(--surface-1);
+    max-inline-size: $size-content-2;
+    text-wrap: pretty;
+}
+
+:where(td,th) {
+    text-align: left;
+    padding: $size-2;
+}
+
 :where(:is(td,th):not([align])) {
     text-align: center;
 }
 
 :where(thead) {
     border-collapse: collapse;
+}
+
+:where(table tr:hover td),
+:where(tbody tr:nth-child(even):hover td) {
+    background-color: $gray-10;
+
+    @include color-scheme($OSlight) {
+        background-color: white;
+    }
+}
+
+:where(table > caption) {
+    margin: $size-3;
+}
+
+:where(tfoot button) {
+    padding-block: $size-1;
+    padding-inline: $size-3;
 }

--- a/src/app/styles/global/_theme.dark.scss
+++ b/src/app/styles/global/_theme.dark.scss
@@ -16,4 +16,8 @@
             background-color: var(--surface-2);
         }
     }
+
+    :where(textarea, select, input:not([type='button'],[type='submit'],[type='reset'])) {
+        background-color: hsl(210deg 11% 10%);
+    }
 }

--- a/src/app/styles/global/_theme.light.scss
+++ b/src/app/styles/global/_theme.light.scss
@@ -16,4 +16,8 @@
             background-color: var(--surface-1);
         }
     }
+
+    :where(textarea, select, input:not([type='button'],[type='submit'],[type='reset'])) {
+        background-color: var(--surface-2);
+    }
 }

--- a/src/app/styles/utilities/_flow.scss
+++ b/src/app/styles/utilities/_flow.scss
@@ -1,0 +1,6 @@
+/* Flow Utility
+provides flow and rhythm between direct sibling elements
+*/
+.flow > * + * {
+    margin-top: var(--flow-space, 1em);
+}

--- a/src/app/styles/utilities/_region.scss
+++ b/src/app/styles/utilities/_region.scss
@@ -1,0 +1,7 @@
+/*
+REGION UTILITY
+Consistent block padding for page sections
+*/
+.region {
+    padding-block: var(--region-space, var(--space-size-3));
+}

--- a/src/app/styles/utilities/_visually-hidden.scss
+++ b/src/app/styles/utilities/_visually-hidden.scss
@@ -1,0 +1,11 @@
+.visually-hidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 0;
+    margin: 0;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+}

--- a/src/app/styles/utilities/_wrapper.scss
+++ b/src/app/styles/utilities/_wrapper.scss
@@ -1,0 +1,10 @@
+/*
+WRAPPER UTILITY
+A common wrapper/container
+*/
+.wrapper {
+    margin-inline: auto;
+    width: clamp(16rem, 95vw, 85rem);
+    padding-inline: var(--space-size-1);
+    position: relative;
+}

--- a/src/app/styles/variables/_borders.variables.scss
+++ b/src/app/styles/variables/_borders.variables.scss
@@ -4,4 +4,5 @@ $border-size-3: 5px;
 
 $radius-1: 2px;
 $radius-2: 5px;
+$radius-3: 1rem;
 $radius-round: 1e5px;

--- a/src/app/styles/variables/_colors.variables.scss
+++ b/src/app/styles/variables/_colors.variables.scss
@@ -1,3 +1,17 @@
+$blue-0: #e7f5ff;
+$blue-1: #d0ebff;
+$blue-2: #a5d8ff;
+$blue-3: #74c0fc;
+$blue-4: #4dabf7;
+$blue-5: #339af0;
+$blue-6: #228be6;
+$blue-7: #1c7ed6;
+$blue-8: #1971c2;
+$blue-9: #1864ab;
+$blue-10: #145591;
+$blue-11: #114678;
+$blue-12: #0d375e;
+
 $gray-0: #f8f9fa;
 $gray-1: #f1f3f5;
 $gray-2: #e9ecef;
@@ -11,6 +25,20 @@ $gray-9: #212529;
 $gray-10: #16191d;
 $gray-11: #0d0f12;
 $gray-12: #030507;
+
+$green-0: #ebfbee;
+$green-1: #d3f9d8;
+$green-2: #b2f2bb;
+$green-3: #8ce99a;
+$green-4: #69db7c;
+$green-5: #51cf66;
+$green-6: #40c057;
+$green-7: #37b24d;
+$green-8: #2f9e44;
+$green-9: #2b8a3e;
+$green-10: #237032;
+$green-11: #1b5727;
+$green-12: #133d1b;
 
 $indigo-0: #edf2ff;
 $indigo-1: #dbe4ff;
@@ -39,3 +67,17 @@ $purple-9: #862e9c;
 $purple-10: #702682;
 $purple-11: #5a1e69;
 $purple-12: #44174f;
+
+$red-0: #fff5f5;
+$red-1: #ffe3e3;
+$red-2: #ffc9c9;
+$red-3: #ffa8a8;
+$red-4: #ff8787;
+$red-5: #ff6b6b;
+$red-6: #fa5252;
+$red-7: #f03e3e;
+$red-8: #e03131;
+$red-9: #c92a2a;
+$red-10: #b02525;
+$red-11: #962020;
+$red-12: #7d1a1a;

--- a/src/app/styles/variables/_variables.scss
+++ b/src/app/styles/variables/_variables.scss
@@ -4,3 +4,4 @@ $OSdark: 'dark';
 $OSlight: 'light';
 
 $color-mode-type: 'media-query';
+$nice-inner-radius: calc($radius-3 - 2px);

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,3 +1,4 @@
+/* --- Variables --- */
 @import './app/styles/variables/fonts.variables';
 @import './app/styles/variables/colors.variables';
 @import './app/styles/variables/sizes.variables';
@@ -5,8 +6,13 @@
 @import './app/styles/variables/easing.variables';
 @import './app/styles/variables/variables';
 
+/* --- Mixins --- */
 @import './app/styles/mixins/media.preference';
 
+/* --- Utilities --- */
+
+/* --- Global Styles --- */
 @import './app/styles/global/normalize';
 @import './app/styles/global/theme.light';
 @import './app/styles/global/theme.dark';
+@import './app/styles/global/theme';


### PR DESCRIPTION
### Modification and additions to starter page stylesheets
1. Modify normalize to include and extend reset for other elements
2. Add flow, region, visually-hidden, and wrapper utility classes